### PR TITLE
Keycloak version update: General Updates to Helm templates

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
 name: iris_keycloak
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.1.0
+appVersion: 1.1.0
 keywords:
 - iris_keycloak
 dependencies:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 
 SPDX-License-Identifier: CC0-1.0    
 -->
@@ -15,17 +15,18 @@ Default settings in this template are prepared for non-prod environments.
 
 ## Version
 
-| Installed software versions | Version Info            |    
-|-----------------------------|-------------------------|
-| Keycloak                    | 21.1.2                  |
-| PostgreSQL                  | 12.3                    |
+| Installed software versions | Version Info |    
+|-----------------------------|--------------|
+| Keycloak                    | 26.0.8       |
+| java                        | 17.0.9       |
+| PostgreSQL                  | 12.3         |
 
 ## Description
 
 **Important links:**
 
 - Keycloak
-    - [Keycloak documentation](https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-21-1-2)
+  - [Keycloak documentation](https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-26-0-0)
     - [Docker image documentation](https://hub.docker.com/r/jboss/keycloak/)
     - [GitHub repository](https://github.com/keycloak/keycloak)
     - [Iris keycloak image (IKI)](https://github.com/telekom/iris-image)

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v1
 name: postgresql
-version: 1.0.0
+version: 1.1.0
 icon: https://www.postgresql.org/media/img/about/press/elephant.png
 appVersion: 12.3.0
 description: PostgreSQL (original) database provided by bitnami

--- a/charts/postgresql/templates/_postgresql.tpl
+++ b/charts/postgresql/templates/_postgresql.tpl
@@ -1,4 +1,6 @@
 {{- define "postgresql.labels" -}}
+app: {{ .Release.Name }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/instance: {{ .Release.Name }}-postgresql
 app.kubernetes.io/name: postgresql
 app.kubernetes.io/component: database

--- a/charts/postgresql/templates/deployment.yml
+++ b/charts/postgresql/templates/deployment.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -24,6 +24,7 @@ spec:
       {{- include "postgresql.labels" $ | nindent 8 }}
     spec:
       {{- include "image_pull_secrets" $ | indent 6 }}
+      securityContext: {{ include "platformSpecificValue" (list $ . ".Values.podSecurityContext") | default "fsGroup: 999" | nindent 8 }}
       containers:
       - name: postgresql
         resources: {{ .Values.resources | toYaml | nindent 10 }}
@@ -31,6 +32,7 @@ spec:
         {{- include "postgresql.env" $ | indent 8 }}
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        securityContext: {{ include "platformSpecificValue" (list $ . ".Values.containerSecurityContext") | default "{}" | nindent 10 }}
         ports:
         - containerPort: {{ .Values.global.database.port | default 5432 }}
           protocol: TCP
@@ -72,4 +74,3 @@ spec:
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: 30
 {{- end }}
-

--- a/charts/postgresql/templates/pvc.yml
+++ b/charts/postgresql/templates/pvc.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "postgresql.pvcName" . }}
+  finalizers: [ kubernetes.io/pvc-protection ]
   labels: {{ include "postgresql.labels" $ | nindent 4 }}
 {{- if .Values.persistence }}
   {{- if .Values.persistence.keepOnDelete }}
@@ -15,8 +16,11 @@ metadata:
   {{- end -}}
 {{- end }}
 spec:
-  storageClassName: {{ include "platformSpecificValue" (list $ . ".Values.global.storageClassName") | default .Values.persistence.storageClassName | default "gp2" }}
+  storageClassName: {{ include "platformSpecificValue" (list $ . ".Values.global.storageClassName") | default .Values.persistence.storageClassName | default "" }}
   accessModes:
     - ReadWriteOnce
   resources: {{ .Values.persistence.resources | toYaml | nindent 4 }}
+{{- if .Values.global.volumeName }}
+  volumeName: {{ .Values.global.volumeName }}
+{{- end }}
 {{- end }}

--- a/charts/postgresql/templates/secret.yaml
+++ b/charts/postgresql/templates/secret.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,5 @@ metadata:
   labels: {{ include "postgresql.labels" $ | nindent 4 }}
 type: Opaque
 stringData:
-  adminPassword: admin
-  databasePassword: pwd
-  {{ end }}
-
+  databasePassword: {{ .Values.global.database.password }}
+{{ end }}

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -7,7 +7,8 @@ global:
     pipeline: {}
     
   platform: kubernetes
-  #storageClassName: gp2
+  #storageClassName: ""
+
   imagePullSecrets: []
 
   imagePullPolicy: IfNotPresent

--- a/templates/_keycloak.tpl
+++ b/templates/_keycloak.tpl
@@ -4,6 +4,9 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/name: keycloak
 {{ include "keycloak.selector" . }}
 app.kubernetes.io/component: idp
+{{- if .Values.global.labels }}
+{{ .Values.global.labels | toYaml }}
+{{- end }}
 {{- end -}}
 
 {{- define "keycloak.selector" -}}
@@ -44,14 +47,22 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
 {{- define "keycloak.env" }}
 - name: KC_HOSTNAME
   value: {{ include "keycloak.adminHost" $ }}
-- name: KC_PROXY
-  value: edge
+- name: KC_PROXY_HEADERS
+  value: "xforwarded"
 - name: KC_HTTP_ENABLED
   value: "true"
-- name: KC_CACHE_CONFIG_FILE  
+- name: KC_CACHE
+  value: "ispn"
+- name: KC_CACHE_STACK
+  value: "kubernetes"
+- name: KC_CACHE_CONFIG_FILE
   value: infinispan.xml
-- name: jgroups.dns.query
-  value: {{ .Release.Name }}-jgroups.{{ .Release.Namespace }}
+- name: QUARKUS_TRANSACTION_MANAGER_ENABLE_RECOVERY
+  value: "false"
+- name: JAVA_OPTS_APPEND
+  value: -Djgroups.dns.query={{ .Release.Name }}-jgroups.{{ .Release.Namespace }}
+- name: URI_METRICS_ENABLED
+  value: "true"
 - name: KEYCLOAK_ADMIN
   value: {{ .Values.adminUsername }}
 - name: KEYCLOAK_ADMIN_PASSWORD
@@ -68,7 +79,7 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
 - name: KC_DB_URL_HOST
   value: {{ include "database.host" $ }}
 - name: KC_DB_URL_DATABASE
-  value: {{ .Values.global.database.database }} 
+  value: {{ .Values.global.database.database }}
 {{- if .Values.global.database.schema }}
 - name: KC_DB_SCHEMA
   value: {{ .Values.global.database.schema }}

--- a/templates/configmap-config.yml
+++ b/templates/configmap-config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,47 +12,67 @@ data:
     <?xml version="1.0" encoding="UTF-8"?>
     <infinispan
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:infinispan:config:13.0 http://www.infinispan.org/schemas/infinispan-config-13.0.xsd"
-            xmlns="urn:infinispan:config:13.0">
-      <cache-container name="keycloak">
-        <transport stack="kubernetes" lock-timeout="60000"/>
-            <local-cache name="realms">
-              <memory storage="HEAP" max-size="10000"/>            
+            xsi:schemaLocation="urn:infinispan:config:15.0 http://www.infinispan.org/schemas/infinispan-config-15.0.xsd"
+            xmlns="urn:infinispan:config:15.0">
+        <cache-container name="keycloak">
+            <transport lock-timeout="60000"/>
+            <local-cache name="realms" simple-cache="true">
+                <encoding>
+                    <key media-type="application/x-java-object"/>
+                    <value media-type="application/x-java-object"/>
+                </encoding>
+                <memory max-count="10000"/>
             </local-cache>
-            <local-cache name="users">
-              <memory storage="HEAP" max-size="10000"/>   
+            <local-cache name="users" simple-cache="true">
+                <encoding>
+                    <key media-type="application/x-java-object"/>
+                    <value media-type="application/x-java-object"/>
+                </encoding>
+                <memory max-count="10000"/>
             </local-cache>
-            <local-cache name="authorization">
-                <memory storage="HEAP" max-size="10000"/>   
-            </local-cache>
-            <local-cache name="keys">
-                <memory storage="HEAP" max-size="1000"/>   
-                <expiration max-idle="3600000"/>
-            </local-cache>
-            <replicated-cache name="work">
-                <expiration lifespan="900000000000000000"/>
-            </replicated-cache>
             <distributed-cache name="sessions" owners="2">
-                <expiration lifespan="900000000000000000"/>
+                <expiration lifespan="-1"/>
             </distributed-cache>
             <distributed-cache name="authenticationSessions" owners="2">
-                <expiration lifespan="900000000000000000"/>
+                <expiration lifespan="-1"/>
             </distributed-cache>
             <distributed-cache name="offlineSessions" owners="2">
-                <expiration lifespan="900000000000000000"/>
+                <expiration lifespan="-1"/>
             </distributed-cache>
             <distributed-cache name="clientSessions" owners="2">
-                <expiration lifespan="900000000000000000"/>
+                <expiration lifespan="-1"/>
             </distributed-cache>
             <distributed-cache name="offlineClientSessions" owners="2">
-                <expiration lifespan="900000000000000000"/>
+                <expiration lifespan="-1"/>
             </distributed-cache>
             <distributed-cache name="loginFailures" owners="2">
-                <expiration lifespan="900000000000000000"/>
+                <expiration lifespan="-1"/>
             </distributed-cache>
+            <local-cache name="authorization" simple-cache="true">
+                <encoding>
+                    <key media-type="application/x-java-object"/>
+                    <value media-type="application/x-java-object"/>
+                </encoding>
+                <memory max-count="10000"/>
+            </local-cache>
+            <replicated-cache name="work">
+                <expiration lifespan="-1"/>
+            </replicated-cache>
+            <local-cache name="keys" simple-cache="true">
+                <encoding>
+                    <key media-type="application/x-java-object"/>
+                    <value media-type="application/x-java-object"/>
+                </encoding>
+                <expiration max-idle="3600000"/>
+                <memory max-count="1000"/>
+            </local-cache>
             <distributed-cache name="actionTokens" owners="2">
-                <memory storage="HEAP" max-size="-1"/>
-                <expiration interval="300000" lifespan="900000000000000000" max-idle="-1"/>
+                <encoding>
+                    <key media-type="application/x-java-object"/>
+                    <value media-type="application/x-java-object"/>
+                </encoding>
+                <expiration max-idle="-1" lifespan="-1" interval="300000"/>
+                <memory max-count="-1"/>
             </distributed-cache>
         </cache-container>
     </infinispan>

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -62,9 +62,9 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ include "platformSpecificValue" (list $ . ".Values.containerSecurityContext") | default "{}" | nindent 10 }}
         {{- if .Values.truststore }}
-        args: ['start --optimized --import-realm --spi-truststore-file-file=/truststore/truststore.jks --spi-truststore-file-password={{ .Values.truststorePassword }} --spi-truststore-file-hostname-verification-policy={{ .Values.hostnameVerificationPolicy }}']
+        args: ['start','--optimized','--spi-truststore-file-file=/truststore/truststore.jks','--spi-truststore-file-password={{ .Values.truststorePassword }}','--spi-truststore-file-hostname-verification-policy={{ .Values.hostnameVerificationPolicy }}']
         {{- else }}
-        args: ['start --optimized --import-realm']
+        args: ['start','--optimized']
         {{- end }}
         env:
         {{- include "keycloak.env" $ | indent 8 }}
@@ -116,9 +116,6 @@ spec:
       - name: ha-proxy-config
         configMap:
           name: {{ .Release.Name }}-ha-proxy-config
-      - name: realms
-        configMap:
-          name: {{ .Release.Name }}-realm
       {{- if .Values.truststore }}
       - name: secrets
         secret:

--- a/templates/service-headless.yml
+++ b/templates/service-headless.yml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-jgroups
+  labels: {{ include "keycloak.labels" $ | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector: {{ include "keycloak.selector" $ | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +8,8 @@ global:
 
   platform: kubernetes
   #pathToSecret: "path/to/secret"
-  #storageClassName: gp2
+  #storageClassName: ""
+  #volumeName: "pvcNameToOverride"
   domain: ""
   labels:
     # fluentd label
@@ -20,25 +21,14 @@ global:
       # external-dns.alpha.kubernetes.io/target: ""
       # kubernetes.io/ingress.class: ""
 
-
   # If imagePullSecrets is not empty, a pull secret will be deployed for each entry otherwise
   # no pull secret will be deployed
-  # If you use Sapling for deployment this will be set automatically
   imagePullSecrets: []
   #- name: secret
   #  registry: https://<your-registry>
   #  username: changeme
   #  password: changeme
   imagePullPolicy: IfNotPresent
-
-  passwordRules:
-    enabled: false
-    length: 12
-    mustMatch:
-      - "[a-z]"
-      - "[A-Z]"
-      - "[0-9]"
-      - "[^a-zA-Z0-9]"
 
   database:
     location: local
@@ -89,46 +79,6 @@ truststorePassword: password
 # WILDCARD: *.hostname
 # STRICT: host.hostname
 hostnameVerificationPolicy: WILDCARD
-# Enable the preconfigured rover realm for rover client access. If you overwrite the realms config, this will be invalidated.
-roverRealmEnabled: false
-# Use this configuration
-# to create realms with public clients
-# This will create a _generated.json in /realms/
-# Note:
-# If you copy your own json files into /realms (via Sapling for example)
-# no _generated.json will be created!
-realms:
-#- name: adfs
-#  enabled: false
-#  accessTokenLifespan: 300
-#  defaultProvider: adfs-idp
-#  clients:
-#  - name: chevron
-#    redirectUris:
-#    - 'http://change.me/*'
-#    webOrigins:
-#    - 'http://change.me'
-#  - name: chevron-ui
-#    rootUrl: 'http://change.me'
-#    redirectUris:
-#    - 'http://change.me/*'
-#    webOrigins:
-#    - 'http://change.me'
-#  identityProviders:
-#    - name: adfs-idp
-#      displayName: ADFS
-#      signingCertificate: MIIC2DCCr...
-#      singleLogoutServiceUrl: https://<server-uri>/adfs/ls/
-#      singleSignOnServiceUrl: https://<server-uri>/adfs/ls/
-#      encryptionPublicKey: MIIC3jCC...
-#      mappers:
-#      - type: adfs-email
-#      - type: adfs-group
-#      - type: custom
-#        name: firstname
-#        attributeName: http://attrurl.me/
-#        category: saml-user-attribute-idp-mapper
-#        userAttribute: firstName
 
 replicas: 1
 


### PR DESCRIPTION
* General Updates to Helm templates (including updates associated with Keycloak v26.0.8)

* Update password for PostgeSQL

* Don't use AWS specific storageClassName for general templates

* Use standard infinispan configuration

* Delete import H2M realms (not completed and irrelevant functionality)

* chore: update copyright year to 2025

* refactor: remove duplicate keycloak.ingress annotations

---------